### PR TITLE
Port to AdwApplicationWindow, use breakpoints for an adaptive layout, and fix the startup page ListBox showing while empty

### DIFF
--- a/data/ui/ApplicationWindow.ui
+++ b/data/ui/ApplicationWindow.ui
@@ -1,68 +1,79 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.36.0 -->
 <interface>
-  <requires lib="gtk" version="4.0"/>
-  <requires lib="Adw" version="1.0"/>
-  <menu id="appmenu">
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">Open...</attribute>
-        <attribute name="action">app.open</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">Save...</attribute>
-        <attribute name="action">app.save</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">Save As...</attribute>
-        <attribute name="action">app.save_as</attribute>
-      </item>
-    </section>
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">Keyboard Shortcuts</attribute>
-        <attribute name="action">win.show-help-overlay</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes" comments="&quot;Footnote&quot; is the application name">About Dungeon Journal</attribute>
-        <attribute name="action">app.about</attribute>
-      </item>
-    </section>
-  </menu>
-  <template class="DungeonJournalApplicationWindow" parent="GtkApplicationWindow">
-    <property name="default_width">800</property>
-    <property name="default_height">600</property>
-    <property name="icon_name">io.github.trytonvanmeer.DungeonJournal</property>
-    <child>
-      <object class="GtkBox">
-        <property name="vexpand">True</property>
-        <property name="orientation">vertical</property>
+    <requires lib="gtk" version="4.0" />
+    <requires lib="Adw" version="1.0" />
+    <menu id="appmenu">
+        <section>
+            <item>
+                <attribute name="label" translatable="yes">Open...</attribute>
+                <attribute name="action">app.open</attribute>
+            </item>
+            <item>
+                <attribute name="label" translatable="yes">Save...</attribute>
+                <attribute name="action">app.save</attribute>
+            </item>
+            <item>
+                <attribute name="label" translatable="yes">Save As...</attribute>
+                <attribute name="action">app.save_as</attribute>
+            </item>
+        </section>
+        <section>
+            <item>
+                <attribute name="label" translatable="yes">Keyboard Shortcuts</attribute>
+                <attribute name="action">win.show-help-overlay</attribute>
+            </item>
+            <item>
+                <attribute name="label" translatable="yes"
+                    comments="&quot;Footnote&quot; is the application name">About Dungeon Journal</attribute>
+                <attribute name="action">app.about</attribute>
+            </item>
+        </section>
+    </menu>
+    <template class="DungeonJournalApplicationWindow" parent="AdwApplicationWindow">
+        <property name="width_request">430</property>
+        <property name="height_request">370</property>
+        <property name="default_width">800</property>
+        <property name="default_height">600</property>
+        <property name="title" translatable="no">DungeonJournal</property>
         <child>
-          <object class="AdwViewStack" id="stack">
-            <child>
-              <placeholder/>
-            </child>
-          </object>
+            <object class="AdwBreakpoint">
+                <condition>max-width: 600sp</condition>
+                <setter object="header_bar" property="title-widget"/>
+                <setter object="switcher_bar" property="reveal">True</setter>
+            </object>
         </child>
-      </object>
-    </child>
-    <child type="titlebar">
-      <object class="AdwHeaderBar">
-        <property name="centering_policy">strict</property>
-        <property name="title-widget">
-          <object class="AdwViewSwitcher" id="headerbar_switcher">
-            <property name="stack">stack</property>
-            <property name="policy">wide</property>
-          </object>
+        <property name="content">
+            <object class="AdwToolbarView" id="toolbar_view">
+                <property name="top-bar-style">raised</property>
+                <child type="top">
+                    <object class="AdwHeaderBar" id="header_bar">
+                        <property name="centering_policy">strict</property>
+                        <property name="title-widget">
+                            <object class="AdwViewSwitcher">
+                                <property name="policy">wide</property>
+                                <property name="stack">stack</property>
+                            </object>
+                        </property>
+                        <child>
+                            <object class="GtkMenuButton" id="appmenu_button">
+                                <property name="icon_name">open-menu-symbolic</property>
+                                <property name="menu-model">appmenu</property>
+                            </object>
+                        </child>
+                    </object>
+                </child>
+                <property name="content">
+                    <object class="AdwViewStack" id="stack">
+                    </object>
+                </property>
+                <child type="bottom">
+                    <object class="AdwViewSwitcherBar" id="switcher_bar">
+                        <property name="stack">stack</property>
+                    </object>
+                </child>
+            </object>
         </property>
-        <child>
-          <object class="GtkMenuButton" id="appmenu_button">
-            <property name="icon_name">open-menu-symbolic</property>
-            <property name="menu-model">appmenu</property>
-          </object>
-        </child>
-      </object>
-    </child>
-  </template>
+    </template>
 </interface>
 

--- a/src/ui/ApplicationWindow.vala
+++ b/src/ui/ApplicationWindow.vala
@@ -5,7 +5,7 @@ using Adw;
 namespace DungeonJournal
 {
     [GtkTemplate (ui = "/io/github/trytonvanmeer/DungeonJournal/ui/ApplicationWindow.ui")]
-    public class ApplicationWindow : Gtk.ApplicationWindow
+    public class ApplicationWindow : Adw.ApplicationWindow
     {
         [GtkChild] private unowned ViewStack stack;
 

--- a/src/ui/StartupWindow.vala
+++ b/src/ui/StartupWindow.vala
@@ -20,14 +20,9 @@ namespace DungeonJournal
 
             this.logo.icon_name = Config.APP_ID;
             this.setup_recents();
-        }
-/*
-        public override void present()
-        {
-            base.present();
             this.hide_listbox_if_empty();
         }
-*/
+
         private void hide_listbox_if_empty()
         {
             if (this.recents_listbox.get_row_at_index(0) == null)


### PR DESCRIPTION
Hi!

The title of the PR is quite self descriptive, but here's the changes I've made

- Port the main window from GtkApplicationWindow to AdwApplicationWindow
- Made the ViewSwitcher adaptive using libadwaita widgets (AdwToolbarView)
- Fixed the StartupWindow ListBox showing while empty

I have a slight issue with the adaptive layout that it doesn't animate like it should, but it does function as expected and everything in the inspector seems to be right, so I assume it's an issue on my end or smth

Next up I'd like to make the StartupWindow into a StartupPage using a Stack and an AdwStatusPage